### PR TITLE
update set-output to new github env file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,6 @@ runs:
           fi
           IFS=', ' read -r -a array <<< "$minmin_maxmax"
           min_thru_max_series=$( for i in `seq ${array[1]} $((array[3]-1))`; do printf "3.$i "; done )
-          echo "::set-output name=matrix::$( echo $min_thru_max_series | jq -cR 'split(" ")' )"
+          echo "matrix=$( echo $min_thru_max_series | jq -cR 'split(" ")' )" >> $GITHUB_OUTPUT
           echo $min_thru_max_series
       shell: bash


### PR DESCRIPTION
`set-ouput` and `save-state` command are moved now to environment files `$GITHUB_OUTPUT` and `$GITHUB_STATE` respectively

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 